### PR TITLE
Do not fail on parsing of ps output

### DIFF
--- a/src/ltm/ProcessesPanel.java
+++ b/src/ltm/ProcessesPanel.java
@@ -211,15 +211,19 @@ public class ProcessesPanel extends JPanel {
                 tableModel.addRow(processInfo);
             }
 
-            // Calculate CPU and Memory percentages
-            double cpuPercentage = calculateCpuPercentage(processData) * 100;
-            double memoryPercentage = calculateMemoryPercentage(processData) * 100;
+            try {
+                // Calculate CPU and Memory percentages
+                double cpuPercentage = calculateCpuPercentage(processData) * 100;
+                double memoryPercentage = calculateMemoryPercentage(processData) * 100;
 
-            // Update the CPU and Memory progress bars
-            cpuProgressBar.setValue((int) cpuPercentage);
-            cpuProgressBar.setString(String.format("CPU: %.0f%%", cpuPercentage));
-            memoryProgressBar.setValue((int) memoryPercentage);
-            memoryProgressBar.setString(String.format("Memory: %.0f%%", memoryPercentage));
+                // Update the CPU and Memory progress bars
+                cpuProgressBar.setValue((int) cpuPercentage);
+                cpuProgressBar.setString(String.format("CPU: %.0f%%", cpuPercentage));
+                memoryProgressBar.setValue((int) memoryPercentage);
+                memoryProgressBar.setString(String.format("Memory: %.0f%%", memoryPercentage));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
 
             // Wait for the process to complete
             int exitCode = process.waitFor();
@@ -227,7 +231,7 @@ public class ProcessesPanel extends JPanel {
                 // Handle any errors if necessary
                 System.err.println("Error executing script. Exit code: " + exitCode);
             }
-        } catch (IOException | InterruptedException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
This is partial fix to #4
The ps returns a command trimmed to 18 chars and some processes may have spaces in their title. Then we parsing by splitting by a space. So there is two problems: unquoted title and its stripping.
From the `man ps`:

>  comm        COMMAND   command  name  (only  the  executable  name).   The output in this column may contain spaces.  (alias ucmd, ucomm).  See also the args format keyword, the -f
>                              option, and the c option.
>                              When specified last, this column will extend to the edge of the display.  If ps can not determine display width, as when output is redirected (piped) into  a
>                              file  or  another  command,  the  output  width  is undefined (it may be 80, unlimited, determined by the TERM variable, and so on).  The COLUMNS environment
>                              variable or --cols option may be used to exactly determine the width in this case.  The w or -w option may be also be used to adjust width.

In fact, the ps only shows contents of the `/proc/` directory. You may run it with `strace ps` to see what it does. So the app should just do the same itself without relaying on the ps. Maybe there are some libraries or existing projects who does this. The IntelliJ Idea and Android Studio do have such process explorers 